### PR TITLE
Fix mirakurun scheduler port

### DIFF
--- a/chinachu/conf/config.json
+++ b/chinachu/conf/config.json
@@ -18,7 +18,7 @@
   "wuiFiler"       : true,
   "wuiConfigurator": true,
 
-  "schedulerMirakurunPath": "http://container-mirakurun:36960/",
+  "schedulerMirakurunPath": "http://container-mirakurun:40772/",
   "schedulerEpgRecordTime": 5,
   "operSchedulerProcessTime" : 5000,
   "operSchedulerIntervalTime" : 600000,


### PR DESCRIPTION
Mirakurunのスケジューラーポートが変更忘れだったようなので修正。
この設定ファイルのままChinachuを動かす人は少ないと思うけども一応修正しました。
