### PR TITLE
gitプロトコルが廃止されたためhttpsに変更

### DIFF
--- a/chinachu/Dockerfile
+++ b/chinachu/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10-alpine
 LABEL maintainer "h-mineta <h-mineta@0nyx.net>"
 
 ENV DOCKER="YES"
-ARG REPOSITORY="git://github.com/Chinachu/Chinachu.git"
+ARG REPOSITORY="https://github.com/Chinachu/Chinachu.git"
 ARG BRANCH="master"
 
 ARG WORK_DIR="/usr/local/chinachu"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     build:
         context: chinachu
         args:
-         - REPOSITORY=git://github.com/Chinachu/Chinachu.git
+         - REPOSITORY=https://github.com/Chinachu/Chinachu.git
          - BRANCH=gamma
     container_name: chinachu
     ports:


### PR DESCRIPTION
 chinachuコンテナのビルドに失敗する #9 に対する修正案です。
変更点: issueの通りgitプロトコルが廃止されてしまったのでhttpsに差し替えました。